### PR TITLE
Adds the option to define a destination filter for stations. This fil…

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ The station ID (hafasId) can be found in a json file [here](https://www.opendata
 | `station_id` | string | The unique identifier of the station (hafasID from json file, e.g. "1144" for "Betriebshof"). | Yes      | —       |
 | `platform`   | string | Optional platform number (e.g. "A", "B", ...). | No       | (empty) |
 | `line`       | string | Optional specific line to monitor at the station (e.g. "33", "24", ...). | No       | (empty) |
+| `destination filter` | string | Optional to filter for destinations | No | (empty, filtering nothing) |
+
+##### **Destination Filter:**  
+The destination filter needs to be a regular expression, in the simplest case just the name of the destination. This can be `Bismarckplatz` for example. You can choose more complex rules such as filtering out destinations `^((?!Bismarckplatz).)*$`, which might be beneficial depending on your needs.  
 
 #### **Remove a station:**  
 Select a station from your saved list to remove it (this also deletes associated devices).

--- a/custom_components/rnv/config_flow.py
+++ b/custom_components/rnv/config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from typing import Any
+import re
 
 import voluptuous as vol
 
@@ -373,6 +374,7 @@ class RnvOptionsFlowHandler(config_entries.OptionsFlow):
                 "id": user_input["station_id"],
                 "platform": user_input.get("platform", ""),
                 "line": user_input.get("line", ""),
+                "destinationLabel_filter": user_input.get("destinationLabel_filter", ""),
             }
             # Prevent duplicates
             for s in self.stations:
@@ -380,9 +382,17 @@ class RnvOptionsFlowHandler(config_entries.OptionsFlow):
                     s["id"] == new_station["id"]
                     and s.get("platform", "") == new_station["platform"]
                     and s.get("line", "") == new_station["line"]
+                    and s.get("destinationLabel_filter", "") == new_station["destinationLabel_filter"]
                 ):
                     errors["base"] = "duplicate_station"
                     break
+
+            # Check if regex is compilable, so we don't crash later.     
+            try:
+                re.compile(new_station["destinationLabel_filter"])
+            except:
+                errors["base"]="destinationLabel_filter_no_valid_regex"
+                
             if not errors:
                 self.stations.append(new_station)
                 return await self.async_step_menu()
@@ -394,6 +404,7 @@ class RnvOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Required("station_id"): str,
                     vol.Optional("platform", default=""): str,
                     vol.Optional("line", default=""): str,
+                    vol.Optional("destinationLabel_filter", default=""): str,
                 }
             ),
             errors=errors,
@@ -412,8 +423,8 @@ class RnvOptionsFlowHandler(config_entries.OptionsFlow):
             return await self.async_step_menu()
 
         stations_dict = {
-            str(idx): f"{s['id']} ({', '.join([v for v in (s.get('platform'), s.get('line')) if v])})"
-            if s.get("platform") or s.get("line")
+            str(idx): f"{s['id']} ({', '.join([v for v in (s.get('platform'), s.get('line'), s.get('destinationLabel_filter')) if v])})"
+            if s.get("platform") or s.get("line") or s.get("destinationLabel_filter")
             else f"{s['id']}"
             for idx, s in enumerate(self.stations)
         }

--- a/custom_components/rnv/sensor.py
+++ b/custom_components/rnv/sensor.py
@@ -400,33 +400,6 @@ class RNVNextNextNextDepartureSensor(RNVBaseSensor):
         """Return extra state attributes for the third departure sensor."""
         return self._current_attrs_for_index(2)
 
-class RNVDepartureListSensor(RNVBaseSensor):
-    """Sensor entity for the next RNV departure.
-
-    Tracks and exposes the next upcoming departure for a specific station, platform, and line.
-    """
-
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return "Departure List"
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique ID for the next departure sensor."""
-        return self._unique_base_id()+"_list"
-        
-    @property
-    def state(self) -> str | None:
-        """Return the ISO formatted departure time for the next upcoming departure."""
-        return self._current_state_for_index(0)
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Return extra state attributes for the next departure sensor."""
-        return {"departures": [self._current_attrs_for_index(0),self._current_attrs_for_index(1),self._current_attrs_for_index(2),self._current_attrs_for_index(3)]}
-
-
 async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
     """Set up RNV departure sensors from a config entry.
 
@@ -504,17 +477,6 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
                 departure_index=2,
             )
         )
-        entities.append(
-            RNVDepartureListSensor(
-                coordinator,
-                station_id,
-                platform,
-                line,
-                destinationLabel_filter,             
-                departure_index=0,
-            )
-        )
-
 
 
     async_add_entities(entities)

--- a/custom_components/rnv/sensor.py
+++ b/custom_components/rnv/sensor.py
@@ -7,6 +7,7 @@ from RNV stations, including next, second, and third departures, with platform a
 from datetime import UTC, datetime, timedelta
 import logging
 from typing import Any
+import re
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -55,6 +56,7 @@ class RNVBaseSensor(CoordinatorEntity[RNVCoordinator], RestoreEntity):
         station_id: str,
         platform: str,
         line: str,
+        destinationLabel_filter: str, 
         departure_index: int,
     ) -> None:
         """Initialize the RNVBaseSensor."""
@@ -62,6 +64,7 @@ class RNVBaseSensor(CoordinatorEntity[RNVCoordinator], RestoreEntity):
         self._station_id = station_id
         self._platform = platform or ""
         self._line = line or ""
+        self._destinationLabel_filter = destinationLabel_filter or ""
         self._departure_index = departure_index
         # restored state/attributes populated in async_added_to_hass
         self._restored_state: str | None = None
@@ -126,11 +129,34 @@ class RNVBaseSensor(CoordinatorEntity[RNVCoordinator], RestoreEntity):
     def device_info(self) -> DeviceInfo:
         """Return device information for the RNV station sensor."""
         return DeviceInfo(
-            identifiers={(self._station_id, self._platform, self._line)},
-            name=f"RNV Station {self._station_id}{f' {self._platform}' if self._platform else ''}{f' {self._line}' if self._line else ''}",
+            identifiers={(self._station_id, self._platform, self._line, self._destinationLabel_filter)},
+            name=f"RNV Station {self._station_id}{f' {self._platform}' if self._platform else ''}{f' {self._line}' if self._line else ''}{f' {self._destinationLabel_filter}' if self._destinationLabel_filter else ''}",
             manufacturer="Rhein-Neckar-Verkehr GmbH",
             model="Live Departures",
         )
+        
+    def _get_desired_stops(self, journey: dict) -> dict:
+        """Return journey filtered to only non-invalid anddesired stops"""
+
+        # Filter out invalid stops (e.g., destination label contains "$")
+        stops = journey.get("stops", [])
+        filtered_stops = [
+            s for s in stops if "$" not in s.get("destinationLabel", "")
+        ]
+        
+        # If a destination filter is defined, apply it. 
+        if self._destinationLabel_filter:
+            # Filter out undesired end locations
+            re_destinationLabel_filter = re.compile(self._destinationLabel_filter)
+            filtered_stops = [
+                s for s in filtered_stops if re_destinationLabel_filter.search(s.get("destinationLabel", ""))
+            ]
+
+        if filtered_stops is not stops:
+            # Persist the filtered list back into the cached coordinator data
+            # so other sensors won't see invalid entries either
+            journey["stops"] = filtered_stops
+        return filtered_stops
 
     def _extract_departure(self, index: int) -> str | None:
         """Extract the ISO formatted departure time at the given index."""
@@ -149,16 +175,8 @@ class RNVBaseSensor(CoordinatorEntity[RNVCoordinator], RestoreEntity):
         language = (self.hass.config.language or "en").lower()
 
         for journey in elements:
-            # Filter out invalid stops (e.g., destination label contains "$")
-            stops = journey.get("stops", [])
-            filtered_stops = [
-                s for s in stops if "$" not in s.get("destinationLabel", "")
-            ]
-            if filtered_stops is not stops:
-                # Persist the filtered list back into the cached coordinator data
-                # so other sensors won't see invalid entries either
-                journey["stops"] = filtered_stops
-
+            filtered_stops = self._get_desired_stops(journey)
+            
             for stop in filtered_stops:
                 platform_label = stop.get("pole", {}).get("platform", {}).get("label")
                 line = journey.get("line", {}).get("lineGroup", {}).get("label")
@@ -215,15 +233,7 @@ class RNVBaseSensor(CoordinatorEntity[RNVCoordinator], RestoreEntity):
         language = (self.hass.config.language or "en").lower()
 
         for journey in elements:
-            # Filter out invalid stops (e.g., destination label contains "$")
-            stops = journey.get("stops", [])
-            filtered_stops = [
-                s for s in stops if "$" not in s.get("destinationLabel", "")
-            ]
-            if filtered_stops is not stops:
-                # Persist the filtered list back into the cached coordinator data
-                journey["stops"] = filtered_stops
-
+            filtered_stops = self._get_desired_stops(journey)
             for stop in filtered_stops:
                 platform_label = stop.get("pole", {}).get("platform", {}).get("label")
                 line = journey.get("line", {}).get("lineGroup", {}).get("label")
@@ -302,6 +312,10 @@ class RNVBaseSensor(CoordinatorEntity[RNVCoordinator], RestoreEntity):
         if index is not None and index < len(journeys_info):
             return journeys_info[index][1]
         return None
+        
+    def _unique_base_id(self) -> str:
+        """Return a unique base ID for derived classes to amend."""
+        return f"rnv_{self._station_id}{f'_{self._platform}' if self._platform else ''}{f'_{self._line}' if self._line else ''}{f'_filter{str(hash(self._destinationLabel_filter))[:6]}' if self._destinationLabel_filter else ''}"
 
 
 class RNVNextDepartureSensor(RNVBaseSensor):
@@ -318,8 +332,8 @@ class RNVNextDepartureSensor(RNVBaseSensor):
     @property
     def unique_id(self) -> str:
         """Return the unique ID for the next departure sensor."""
-        return f"rnv_{self._station_id}{f'_{self._platform}' if self._platform else ''}{f'_{self._line}' if self._line else ''}_next"
-
+        return self._unique_base_id()+"_next"
+        
     @property
     def state(self) -> str | None:
         """Return the ISO formatted departure time for the next upcoming departure."""
@@ -345,7 +359,7 @@ class RNVNextNextDepartureSensor(RNVBaseSensor):
     @property
     def unique_id(self) -> str:
         """Return the unique ID for the second departure sensor."""
-        return f"rnv_{self._station_id}{f'_{self._platform}' if self._platform else ''}{f'_{self._line}' if self._line else ''}_second"
+        return self._unique_base_id()+"_second"
 
     @property
     def state(self) -> str | None:
@@ -372,7 +386,7 @@ class RNVNextNextNextDepartureSensor(RNVBaseSensor):
     @property
     def unique_id(self) -> str:
         """Return the unique ID for the third departure sensor."""
-        return f"rnv_{self._station_id}{f'_{self._platform}' if self._platform else ''}{f'_{self._line}' if self._line else ''}_third"
+        return self._unique_base_id()+"_third"
 
     @property
     def state(self) -> str | None:
@@ -419,6 +433,7 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
         station_id = station["id"]
         platform = station.get("platform", "")
         line = station.get("line", "")
+        destinationLabel_filter = station.get("destinationLabel_filter", "") #JD
 
         coordinator = RNVCoordinator(
             hass,
@@ -437,6 +452,7 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
                 station_id,
                 platform,
                 line,
+                destinationLabel_filter, 
                 departure_index=0,
             )
         )
@@ -446,6 +462,7 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
                 station_id,
                 platform,
                 line,
+                destinationLabel_filter,                 
                 departure_index=1,
             )
         )
@@ -455,6 +472,7 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
                 station_id,
                 platform,
                 line,
+                destinationLabel_filter,             
                 departure_index=2,
             )
         )

--- a/custom_components/rnv/translations/de.json
+++ b/custom_components/rnv/translations/de.json
@@ -37,7 +37,8 @@
         "data": {
           "station_id": "Haltestellen-ID (hafasId)",
           "platform": "Steig (optional)",
-          "line": "Linie (optional)"
+          "line": "Linie (optional)",          
+          "destinationLabel_filter": "Endstationsfilter (optional, siehe Dokumentation)"
         }
       },
       "remove_station": {
@@ -49,7 +50,8 @@
       }
     },
     "error": {
-      "duplicate_station": "Diese Haltestelle-Steig-Linien Kombination ist bereits konfiguriert."
+      "duplicate_station": "Diese Haltestelle-Steig-Linien Kombination ist bereits konfiguriert.",
+      "destinationLabel_filter_no_valid_regex": "Endstationsfilter ist ungültig, bitte einen gültigen regulären Ausdruck benutzen."
     }
   }
 }

--- a/custom_components/rnv/translations/en.json
+++ b/custom_components/rnv/translations/en.json
@@ -37,7 +37,8 @@
         "data": {
           "station_id": "Station ID (hafasId)",
           "platform": "Platform (optional)",
-          "line": "Line (optional)"
+          "line": "Line (optional)",
+          "destinationLabel_filter": "Destination filter (regexp, optional)"
         }
       },
       "remove_station": {
@@ -49,7 +50,8 @@
       }
     },
     "error": {
-      "duplicate_station": "This station-platform-line combination is already configured."
+      "duplicate_station": "This station-platform-line combination is already configured.",
+      "destinationLabel_filter_no_valid_regex": "Destination filter invalid, please provide a valid regular expression."
     }
   }
 }


### PR DESCRIPTION
Adds the option to define a destination filter for stations. This filter works as a regular expression.

New user strings
 - `destinationLabel_filter` for decorating the input filed.
 - `destinationLabel_filter_no_valid_regex` for reporting back, if the filter is not a valid regex.

Details:
 - class `RNVBaseSensor` now has a function `_get_desired_stops` that does the previous task 'Filter out invalid stops (e.g., destination label contains "$")'. This function also handles the regex filtering of the destinationLabel. Previous code duplication was also removed my introducing this function.
 - class `RNVBaseSensor` now has a function  `_unique_base_id` to include the destination filter and to perform the previous generation of the base unique_id. Previous code duplication was also removed my introducing this function.  Note, the unique_id does not simply use the `_destinationLabel_filter` because regular expressions may contain unwanted characters for the unique_id (^, $, ...). This is why a hashing approach was used.
 - Naming of the respective device also includes the destination filter, if applicable. As well as the duplicate detection.
 - Readme.md was updated to include this and some examples.